### PR TITLE
Minimize `apt-get` extras in the test runner for a smaller image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && \
 RUN filename="euphoria-${OPEN_EUPHORIA_VERSION}-${OPEN_EUPHORIA_ARCH}-${OPEN_EUPHORIA_SHA}.tar.gz" && \
     curl -L -O "https://github.com/OpenEuphoria/euphoria/releases/download/${OPEN_EUPHORIA_VERSION}/${filename}" && \
     tar -xzf "${filename}" -C /usr/local && \
+    rm -f "${filename}" && \
     cd /usr/local/bin && \
     find "/usr/local/euphoria-${OPEN_EUPHORIA_VERSION}-${OPEN_EUPHORIA_ARCH}/bin" -type f -executable -exec ln -s {} \; && \
     eui --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ ARG OPEN_EUPHORIA_ARCH=Linux-x64
 ARG OPEN_EUPHORIA_VERSION=4.1.0
 ARG OPEN_EUPHORIA_SHA=57179171dbed
 
-RUN apt update && apt install -y curl
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends curl ca-certificates && \
+    apt-get purge --auto-remove --yes && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN filename="euphoria-${OPEN_EUPHORIA_VERSION}-${OPEN_EUPHORIA_ARCH}-${OPEN_EUPHORIA_SHA}.tar.gz" && \
     curl -L -O "https://github.com/OpenEuphoria/euphoria/releases/download/${OPEN_EUPHORIA_VERSION}/${filename}" && \


### PR DESCRIPTION
Ignoring the common Ubuntu base, this reduces the Euphoria test runner storage from 127.8MB to 50.3 for a 77.5MB (60%) savings.